### PR TITLE
Social media tags still had some references to Madrid's participa site.

### DIFF
--- a/app/views/shared/_social_media_meta_tags.html.erb
+++ b/app/views/shared/_social_media_meta_tags.html.erb
@@ -1,16 +1,16 @@
 <!-- Twitter -->
 <meta name="twitter:card" content="summary" />
-<meta name="twitter:site" content="@abriendomadrid" />
+<meta name="twitter:site" content="@PlazaPodemos" />
 <meta name="twitter:title" content="<%= social_title %>" />
 <meta name="twitter:description" content="<%= social_description %>" />
 <meta name="twitter:image" content="<%= image_url '/social-media-icon.png' %>" />
 <!-- Facebook OG -->
 <meta id="ogtitle" property="og:title" content="<%= social_title %>"/>
-<meta property="article:publisher" content="http://decide.madrid.es"/>
+<meta property="article:publisher" content="https://plaza.podemos.info"/>
 <meta property="article:author" content="https://www.facebook.com/Podemos-269212336568846"/>
 <meta property="og:type" content="article"/>
 <meta id="ogurl" property="og:url" content="<%= social_url %>"/>
 <meta id="ogimage" property="og:image" content="<%= image_url '/social-media-icon.png' %>"/>
-<meta property="og:site_name" content="Madrid Participación"/>
+<meta property="og:site_name" content="Plaza Podemos 2.0"/>
 <meta id="ogdescription" property="og:description" content="<%= social_description %>"/>
 <meta property="fb:app_id" content="1662598980652932"/>


### PR DESCRIPTION
Update Consul references like @abriendomadrid and "Madrid Participación" in _social_media_tag. When sharing something on twitter the source was @abriendomadrid. Using @plazapodemos.

TODO: fb:app_id should be updated too.
